### PR TITLE
Fix setuptools config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 # This includes the license file in the wheel.
-license_file = LICENSE
+license_files = LICENSE
 
 [bdist_wheel]
 # This flag says to generate wheels that support both Python 2 and Python

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ setup(
     version=versioneer.get_version(),
     author="Thomas G. Close",
     author_email="tom.g.close@gmail.com",
-    packages=find_namespace_packages(),
+    packages=find_namespace_packages(
+        include=['medimages4tests*'],
+    ),
     url="https://github.com/australian-imaging-service/medimages4tests",
     license="CC0",
     description=(


### PR DESCRIPTION
Using just `find_namespace_packages()` will install `scripts` and
`tests` as top level modules in `site-packages/`. Specifying what to
include avoids that.

Quench deprecation warning regarding `license_file` in `setup.cfg`. The
correct parameter is `license_files` (plural).
