### PR TITLE
added check for pydicom version before using enforce pydicom write

### DIFF
--- a/medimages4tests/dummy/dicom/base.py
+++ b/medimages4tests/dummy/dicom/base.py
@@ -81,7 +81,7 @@ def generate_dicom(
             ds = pydicom.dataset.Dataset.from_json(vol_json)
             ds.is_implicit_VR = True
             ds.is_little_endian = True
-            if sys.version_info < (3, 10):
+            if sys.version_info < (3, 10) or pydicom.__version__.split(".")[0] < "3":
                 save_kwargs = {"write_like_original": False}
             else:
                 save_kwargs = {"enforce_file_format": True}


### PR DESCRIPTION
The write options changed in pydicom v3~ and so we need to check which one we are using before selecting the appropriate option